### PR TITLE
Fixed sampler limit exceeded compile errors and other shader warnings.

### DIFF
--- a/Examples/SplatMapping/Shaders/SplatBlendSpecular_1Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlendSpecular_1Layer.shader
@@ -58,11 +58,11 @@ Shader "VertexPainter/SplatBlendSpecular_1Layer"
          float2 uv1 = IN.uv_Tex1 * _TexScale1;
          INIT_FLOW
          #if _FLOWDRIFT || !_PARALLAXMAP 
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
          #endif
          
          #if _PARALLAXMAP
@@ -73,13 +73,13 @@ Shader "VertexPainter/SplatBlendSpecular_1Layer"
          fuv1 += offset;
          fuv2 += offset;
          #endif
-         c1 = FETCH_TEX1(_Tex1, uv1);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
          #endif
 
          c1 *= _Tint1;
 
          #if _SPECGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, uv1);
+         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, _SpecGlossMap1, uv1);
          o.Smoothness = g1.a;
          o.Specular = g1.rgb;
          #else
@@ -87,14 +87,13 @@ Shader "VertexPainter/SplatBlendSpecular_1Layer"
          o.Specular = _SpecColor1.rgb;
          #endif 
          
-         
          #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
          o.Emission = e1.rgb * _EmissiveMult1;
          #endif
          
          #if _NORMALMAP
-         fixed4 n1 = FETCH_TEX1(_Normal1, uv1);
+         fixed4 n1 = FETCH_TEX1(_Normal1, _Normal1, uv1);
          o.Normal = UnpackNormal(n1);
          #endif
          

--- a/Examples/SplatMapping/Shaders/SplatBlendSpecular_2Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlendSpecular_2Layer.shader
@@ -75,14 +75,14 @@ Shader "VertexPainter/SplatBlendSpecular_2Layer"
          float2 uv2 = IN.uv_Tex1 * _TexScale2;
          INIT_FLOW
          #if _FLOWDRIFT || !_PARALLAXMAP 
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
-         fixed4 c2 = FETCH_TEX2(_Tex2, uv2);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         fixed4 c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
-         fixed4 c2 = lerp(tex2D(_Tex2, uv2), tex2D(_Tex2, uv2*_DistUVScale2), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c2 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2*_DistUVScale2), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
-         fixed4 c2 = tex2D(_Tex2, uv2);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
+         fixed4 c2 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2);
          #endif
 
          
@@ -90,10 +90,10 @@ Shader "VertexPainter/SplatBlendSpecular_2Layer"
          #if _FLOW2
             b1 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX2 (_Normal2, uv2) - 0.5;
+               half4 rn = FETCH_TEX2 (_Normal2, _Normal1, uv2) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
                #endif
             #endif
          #endif
@@ -103,8 +103,8 @@ Shader "VertexPainter/SplatBlendSpecular_2Layer"
          float2 offset = ParallaxOffset (lerp(c1.a, c2.a, b1), parallax, IN.viewDir);
          uv1 += offset;
          uv2 += offset;
-         c1 = FETCH_TEX1(_Tex1, uv1);
-         c2 = FETCH_TEX2(_Tex2, uv2);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
          #if (_FLOW1 || _FLOW2 || _FLOW3 || _FLOW4 || _FLOW5)
          fuv1 += offset;
          fuv2 += offset;
@@ -114,8 +114,8 @@ Shader "VertexPainter/SplatBlendSpecular_2Layer"
          fixed4 c = lerp(c1 * _Tint1, c2 * _Tint2, b1);
 
          #if _SPECGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, uv1);
-         fixed4 g2 = FETCH_TEX2(_SpecGlossMap2, uv2);
+         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, _SpecGlossMap1, uv1);
+         fixed4 g2 = FETCH_TEX2(_SpecGlossMap2, _SpecGlossMap1, uv2);
          fixed4 gf = lerp(g1, g2, b1);
          o.Smoothness = gf.a;
          o.Specular = gf.rgb;
@@ -125,14 +125,14 @@ Shader "VertexPainter/SplatBlendSpecular_2Layer"
          #endif
          
          #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
-         fixed4 e2 = FETCH_TEX2(_Emissive2, uv2);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
+         fixed4 e2 = FETCH_TEX2(_Emissive2, _Emissive1, uv2);
          o.Emission = lerp(e1.rgb * _EmissiveMult1, e2.rgb * _EmissiveMult2, b1);
          #endif
          
          #if _NORMALMAP
-         half4 n1 = FETCH_TEX1 (_Normal1, uv1);
-         half4 n2 = FETCH_TEX2 (_Normal2, uv2);
+         half4 n1 = FETCH_TEX1 (_Normal1, _Normal1, uv1);
+         half4 n2 = FETCH_TEX2 (_Normal2, _Normal1, uv2);
          o.Normal = UnpackNormal(lerp(n1, n2, b1));
          #endif
          o.Albedo = c.rgb;

--- a/Examples/SplatMapping/Shaders/SplatBlendSpecular_3Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlendSpecular_3Layer.shader
@@ -90,17 +90,17 @@ Shader "VertexPainter/SplatBlendSpecular_3Layer"
          float2 uv3 = IN.uv_Tex1 * _TexScale3;
          INIT_FLOW
          #if _FLOWDRIFT || !_PARALLAXMAP 
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
-         fixed4 c2 = FETCH_TEX2(_Tex2, uv2);
-         fixed4 c3 = FETCH_TEX3(_Tex3, uv3);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         fixed4 c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         fixed4 c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
-         fixed4 c2 = lerp(tex2D(_Tex2, uv2), tex2D(_Tex2, uv2*_DistUVScale2), dist);
-         fixed4 c3 = lerp(tex2D(_Tex3, uv3), tex2D(_Tex3, uv3*_DistUVScale3), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c2 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2*_DistUVScale2), dist);
+         fixed4 c3 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3*_DistUVScale3), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
-         fixed4 c2 = tex2D(_Tex2, uv2);
-         fixed4 c3 = tex2D(_Tex3, uv3);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
+         fixed4 c2 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2);
+         fixed4 c3 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3);
          #endif
          
          half b1 = HeightBlend(c1.a, c2.a, IN.color.r, _Contrast2);
@@ -110,22 +110,22 @@ Shader "VertexPainter/SplatBlendSpecular_3Layer"
          #if _FLOW2
             b1 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX2 (_Normal2, uv2) - 0.5;
+               half4 rn = FETCH_TEX2 (_Normal2, _Normal1, uv2) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
                #endif
             #endif
          #endif
          #if _FLOW3
             b2 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX3 (_Normal3, uv3) - 0.5;
+               half4 rn = FETCH_TEX3 (_Normal3, _Normal1, uv3) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
                #endif
             #endif
          #endif
@@ -137,9 +137,9 @@ Shader "VertexPainter/SplatBlendSpecular_3Layer"
          uv1 += offset;
          uv2 += offset;
          uv3 += offset;
-         c1 = FETCH_TEX1(_Tex1, uv1);
-         c2 = FETCH_TEX2(_Tex2, uv2);
-         c3 = FETCH_TEX3(_Tex3, uv3);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
           #if (_FLOW1 || _FLOW2 || _FLOW3 || _FLOW4 || _FLOW5)
          fuv1 += offset;
          fuv2 += offset;
@@ -149,9 +149,9 @@ Shader "VertexPainter/SplatBlendSpecular_3Layer"
          fixed4 c = lerp(lerp(c1 * _Tint1, c2 * _Tint2, b1), c3 * _Tint3, b2);
 
          #if _SPECGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, uv1);
-         fixed4 g2 = FETCH_TEX2(_SpecGlossMap2, uv2);
-         fixed4 g3 = FETCH_TEX3(_SpecGlossMap3, uv3);
+         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, _SpecGlossMap1, uv1);
+         fixed4 g2 = FETCH_TEX2(_SpecGlossMap2, _SpecGlossMap1, uv2);
+         fixed4 g3 = FETCH_TEX3(_SpecGlossMap3, _SpecGlossMap1, uv3);
          fixed4 gf = lerp(lerp(g1, g2, b1), g3, b2);
          o.Smoothness = gf.a;
          o.Specular = gf.rgb;
@@ -161,18 +161,18 @@ Shader "VertexPainter/SplatBlendSpecular_3Layer"
          #endif
          
          #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
-         fixed4 e2 = FETCH_TEX2(_Emissive2, uv2);
-         fixed4 e3 = FETCH_TEX3(_Emissive3, uv3);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
+         fixed4 e2 = FETCH_TEX2(_Emissive2, _Emissive1, uv2);
+         fixed4 e3 = FETCH_TEX3(_Emissive3, _Emissive1, uv3);
          o.Emission = lerp(lerp(e1.rgb * _EmissiveMult1, 
                                 e2.rgb * _EmissiveMult2, b1), 
                                 e3.rgb * _EmissiveMult3, b2);
          #endif
          
          #if _NORMALMAP
-         half4 n1 = (FETCH_TEX1 (_Normal1, uv1));
-         half4 n2 = (FETCH_TEX2 (_Normal2, uv2));
-         half4 n3 = (FETCH_TEX3 (_Normal3, uv3));
+         half4 n1 = (FETCH_TEX1 (_Normal1, _Normal1, uv1));
+         half4 n2 = (FETCH_TEX2 (_Normal2, _Normal1, uv2));
+         half4 n3 = (FETCH_TEX3 (_Normal3, _Normal1, uv3));
          o.Normal = UnpackNormal(lerp(lerp(n1, n2, b1), n3, b2));
          #endif
          

--- a/Examples/SplatMapping/Shaders/SplatBlendSpecular_4Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlendSpecular_4Layer.shader
@@ -109,20 +109,20 @@ Shader "VertexPainter/SplatBlendSpecular_4Layer"
          float2 uv4 = IN.uv_Tex1 * _TexScale4;
          INIT_FLOW
          #if _FLOWDRIFT || !_PARALLAXMAP
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
-         fixed4 c2 = FETCH_TEX2(_Tex2, uv2);
-         fixed4 c3 = FETCH_TEX3(_Tex3, uv3);
-         fixed4 c4 = FETCH_TEX4(_Tex4, uv4);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         fixed4 c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         fixed4 c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+         fixed4 c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
-         fixed4 c2 = lerp(tex2D(_Tex2, uv2), tex2D(_Tex2, uv2*_DistUVScale2), dist);
-         fixed4 c3 = lerp(tex2D(_Tex3, uv3), tex2D(_Tex3, uv3*_DistUVScale3), dist);
-         fixed4 c4 = lerp(tex2D(_Tex4, uv4), tex2D(_Tex4, uv4*_DistUVScale4), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c2 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2*_DistUVScale2), dist);
+         fixed4 c3 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3*_DistUVScale3), dist);
+         fixed4 c4 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4*_DistUVScale4), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
-         fixed4 c2 = tex2D(_Tex2, uv2);
-         fixed4 c3 = tex2D(_Tex3, uv3);
-         fixed4 c4 = tex2D(_Tex4, uv4);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
+         fixed4 c2 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2);
+         fixed4 c3 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3);
+         fixed4 c4 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4);
          #endif
          half b1 = HeightBlend(c1.a, c2.a, IN.color.r, _Contrast2);
          fixed h1 = lerp(c1.a, c2.a, b1);
@@ -133,36 +133,36 @@ Shader "VertexPainter/SplatBlendSpecular_4Layer"
          #if _FLOW2
             b1 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX2 (_Normal2, uv2) - 0.5;
+               half4 rn = FETCH_TEX2 (_Normal2, _Normal1, uv2) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
                #endif
             #endif
          #endif
          #if _FLOW3
             b2 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX3 (_Normal3, uv3) - 0.5;
+               half4 rn = FETCH_TEX3 (_Normal3, _Normal1, uv3) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
                #endif
             #endif
          #endif
          #if _FLOW4
             b3 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX4 (_Normal4, uv4) - 0.5;
+               half4 rn = FETCH_TEX4 (_Normal4, _Normal1, uv4) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                uv3 += rn.xy * b3 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
-                  c3 = FETCH_TEX3(_Tex3, uv3);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+                  c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
                #endif
             #endif
          #endif
@@ -176,10 +176,10 @@ Shader "VertexPainter/SplatBlendSpecular_4Layer"
          uv2 += offset;
          uv3 += offset;
          uv4 += offset;
-         c1 = FETCH_TEX1(_Tex1, uv1);
-         c2 = FETCH_TEX2(_Tex2, uv2);
-         c3 = FETCH_TEX3(_Tex3, uv3);
-         c4 = FETCH_TEX4(_Tex4, uv4);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+         c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
          #if (_FLOW1 || _FLOW2 || _FLOW3 || _FLOW4 || _FLOW5)
          fuv1 += offset;
          fuv2 += offset;
@@ -191,10 +191,10 @@ Shader "VertexPainter/SplatBlendSpecular_4Layer"
 
 
          #if _SPECGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, uv1);
-         fixed4 g2 = FETCH_TEX2(_SpecGlossMap2, uv2);
-         fixed4 g3 = FETCH_TEX3(_SpecGlossMap3, uv3);
-         fixed4 g4 = FETCH_TEX4(_SpecGlossMap4, uv4);
+         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, _SpecGlossMap1, uv1);
+         fixed4 g2 = FETCH_TEX2(_SpecGlossMap2, _SpecGlossMap1, uv2);
+         fixed4 g3 = FETCH_TEX3(_SpecGlossMap3, _SpecGlossMap1, uv3);
+         fixed4 g4 = FETCH_TEX4(_SpecGlossMap4, _SpecGlossMap1, uv4);
          fixed4 gf = lerp(lerp(lerp(g1, g2, b1), g3, b2), g4, b3);
          o.Smoothness = gf.a;
          o.Specular = gf.rgb;
@@ -205,10 +205,10 @@ Shader "VertexPainter/SplatBlendSpecular_4Layer"
 
          
          #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
-         fixed4 e2 = FETCH_TEX2(_Emissive2, uv2);
-         fixed4 e3 = FETCH_TEX3(_Emissive3, uv3);
-         fixed4 e4 = FETCH_TEX4(_Emissive4, uv4);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
+         fixed4 e2 = FETCH_TEX2(_Emissive2, _Emissive1, uv2);
+         fixed4 e3 = FETCH_TEX3(_Emissive3, _Emissive1, uv3);
+         fixed4 e4 = FETCH_TEX4(_Emissive4, _Emissive1, uv4);
          o.Emission = lerp(lerp(lerp(e1.rgb * _EmissiveMult1, 
                                      e2.rgb * _EmissiveMult2, b1), 
                                      e3.rgb * _EmissiveMult3, b2),
@@ -217,10 +217,10 @@ Shader "VertexPainter/SplatBlendSpecular_4Layer"
          
          
          #if _NORMALMAP
-         half4 n1 =  (FETCH_TEX1 (_Normal1, uv1));
-         half4 n2 =  (FETCH_TEX2 (_Normal2, uv2));
-         half4 n3 =  (FETCH_TEX3 (_Normal3, uv3));
-         half4 n4 =  (FETCH_TEX4 (_Normal4, uv4));
+         half4 n1 =  (FETCH_TEX1 (_Normal1, _Normal1, uv1));
+         half4 n2 =  (FETCH_TEX2 (_Normal2, _Normal1, uv2));
+         half4 n3 =  (FETCH_TEX3 (_Normal3, _Normal1, uv3));
+         half4 n4 =  (FETCH_TEX4 (_Normal4, _Normal1, uv4));
          o.Normal = UnpackNormal(lerp(lerp(lerp(n1, n2, b1), n3, b2), n4, b3));
          #endif
          

--- a/Examples/SplatMapping/Shaders/SplatBlendSpecular_5Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlendSpecular_5Layer.shader
@@ -122,23 +122,23 @@ Shader "VertexPainter/SplatBlendSpecular_5Layer"
          float2 uv5 = IN.uv_Tex1 * _TexScale5;
          INIT_FLOW
          #if _FLOWDRIFT || !_PARALLAXMAP
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
-         fixed4 c2 = FETCH_TEX2(_Tex2, uv2);
-         fixed4 c3 = FETCH_TEX3(_Tex3, uv3);
-         fixed4 c4 = FETCH_TEX4(_Tex4, uv4);
-         fixed4 c5 = FETCH_TEX5(_Tex5, uv5);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         fixed4 c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         fixed4 c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+         fixed4 c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
+         fixed4 c5 = FETCH_TEX5(_Tex5, _Tex1, uv5);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
-         fixed4 c2 = lerp(tex2D(_Tex2, uv2), tex2D(_Tex2, uv2*_DistUVScale2), dist);
-         fixed4 c3 = lerp(tex2D(_Tex3, uv3), tex2D(_Tex3, uv3*_DistUVScale3), dist);
-         fixed4 c4 = lerp(tex2D(_Tex4, uv4), tex2D(_Tex4, uv4*_DistUVScale4), dist);
-         fixed4 c5 = lerp(tex2D(_Tex5, uv5), tex2D(_Tex5, uv5*_DistUVScale5), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c2 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2*_DistUVScale2), dist);
+         fixed4 c3 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3*_DistUVScale3), dist);
+         fixed4 c4 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4*_DistUVScale4), dist);
+         fixed4 c5 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex5, _Tex1, uv5), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex5, _Tex1, uv5*_DistUVScale5), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
-         fixed4 c2 = tex2D(_Tex2, uv2);
-         fixed4 c3 = tex2D(_Tex3, uv3);
-         fixed4 c4 = tex2D(_Tex4, uv4);
-         fixed4 c5 = tex2D(_Tex5, uv5);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
+         fixed4 c2 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2);
+         fixed4 c3 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3);
+         fixed4 c4 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4);
+         fixed4 c5 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex5, _Tex1, uv5);
          #endif
          half b1 = HeightBlend(c1.a, c2.a, IN.color.r, _Contrast2);
          fixed h1 = lerp(c1.a, c2.a, b1);
@@ -151,52 +151,52 @@ Shader "VertexPainter/SplatBlendSpecular_5Layer"
          #if _FLOW2
             b1 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX2 (_Normal2, uv2) - 0.5;
+               half4 rn = FETCH_TEX2 (_Normal2, _Normal1, uv2) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
                #endif
             #endif
          #endif
          #if _FLOW3
             b2 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX3 (_Normal3, uv3) - 0.5;
+               half4 rn = FETCH_TEX3 (_Normal3, _Normal1, uv3) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
                #endif
             #endif
          #endif
          #if _FLOW4
             b3 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX4 (_Normal4, uv4) - 0.5;
+               half4 rn = FETCH_TEX4 (_Normal4, _Normal1, uv4) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                uv3 += rn.xy * b3 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
-                  c3 = FETCH_TEX3(_Tex3, uv3);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+                  c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
                #endif
             #endif
          #endif
          #if _FLOW5
             b4 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX5 (_Normal5, uv5) - 0.5;
+               half4 rn = FETCH_TEX5 (_Normal5, _Normal1, uv5) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                uv3 += rn.xy * b3 * _FlowRefraction;
                uv4 += rn.xy * b4 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
-                  c3 = FETCH_TEX3(_Tex3, uv3);
-                  c4 = FETCH_TEX4(_Tex4, uv4);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+                  c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+                  c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
                #endif
             #endif
          #endif
@@ -210,11 +210,11 @@ Shader "VertexPainter/SplatBlendSpecular_5Layer"
          uv3 += offset;
          uv4 += offset;
          uv5 += offset;
-         c1 = FETCH_TEX1(_Tex1, uv1);
-         c2 = FETCH_TEX2(_Tex2, uv2);
-         c3 = FETCH_TEX3(_Tex3, uv3);
-         c4 = FETCH_TEX4(_Tex4, uv4);
-         c5 = FETCH_TEX5(_Tex5, uv5);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+         c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
+         c5 = FETCH_TEX5(_Tex5, _Tex1, uv5);
          #if (_FLOW1 || _FLOW2 || _FLOW3 || _FLOW4 || _FLOW5)
          fuv1 += offset;
          fuv2 += offset;
@@ -224,20 +224,20 @@ Shader "VertexPainter/SplatBlendSpecular_5Layer"
          fixed4 c = lerp(lerp(lerp(lerp(c1 * _Tint1, c2 * _Tint2, b1), c3 * _Tint3, b2), c4 * _Tint4, b3), c5 * _Tint5, b4);
          
          #if _NORMALMAP
-         half4 n1 =  (FETCH_TEX1 (_Normal1, uv1));
-         half4 n2 =  (FETCH_TEX2 (_Normal2, uv2));
-         half4 n3 =  (FETCH_TEX3 (_Normal3, uv3));
-         half4 n4 =  (FETCH_TEX4 (_Normal4, uv4));
-         half4 n5 =  (FETCH_TEX5 (_Normal5, uv5));
+         half4 n1 =  (FETCH_TEX1 (_Normal1, _Normal1, uv1));
+         half4 n2 =  (FETCH_TEX2 (_Normal2, _Normal1, uv2));
+         half4 n3 =  (FETCH_TEX3 (_Normal3, _Normal1, uv3));
+         half4 n4 =  (FETCH_TEX4 (_Normal4, _Normal1, uv4));
+         half4 n5 =  (FETCH_TEX5 (_Normal5, _Normal1, uv5));
          o.Normal = UnpackNormal(lerp(lerp(lerp(lerp(n1, n2, b1), n3, b2), n4, b3), n5, b4));
          #endif
 
          #if _SPECGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, uv1);
-         fixed4 g2 = FETCH_TEX2(_SpecGlossMap2, uv2);
-         fixed4 g3 = FETCH_TEX3(_SpecGlossMap3, uv3);
-         fixed4 g4 = FETCH_TEX4(_SpecGlossMap4, uv4);
-         fixed4 g5 = FETCH_TEX5(_SpecGlossMap5, uv4);
+         fixed4 g1 = FETCH_TEX1(_SpecGlossMap1, _SpecGlossMap1, uv1);
+         fixed4 g2 = FETCH_TEX2(_SpecGlossMap2, _SpecGlossMap1, uv2);
+         fixed4 g3 = FETCH_TEX3(_SpecGlossMap3, _SpecGlossMap1, uv3);
+         fixed4 g4 = FETCH_TEX4(_SpecGlossMap4, _SpecGlossMap1, uv4);
+         fixed4 g5 = FETCH_TEX5(_SpecGlossMap5, _SpecGlossMap1, uv4);
          fixed4 gf = lerp(lerp(lerp(lerp(g1, g2, b1), g3, b2), g4, b3), g5, b4);
          o.Smoothness = gf.a;
          o.Specular = gf.rgb;
@@ -247,11 +247,11 @@ Shader "VertexPainter/SplatBlendSpecular_5Layer"
          #endif
        
           #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
-         fixed4 e2 = FETCH_TEX2(_Emissive2, uv2);
-         fixed4 e3 = FETCH_TEX3(_Emissive3, uv3);
-         fixed4 e4 = FETCH_TEX4(_Emissive4, uv4);
-         fixed4 e5 = FETCH_TEX5(_Emissive5, uv5);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
+         fixed4 e2 = FETCH_TEX2(_Emissive2, _Emissive1, uv2);
+         fixed4 e3 = FETCH_TEX3(_Emissive3, _Emissive1, uv3);
+         fixed4 e4 = FETCH_TEX4(_Emissive4, _Emissive1, uv4);
+         fixed4 e5 = FETCH_TEX5(_Emissive5, _Emissive1, uv5);
          o.Emission = lerp(lerp(lerp(lerp(e1.rgb * _EmissiveMult1, 
                                      e2.rgb * _EmissiveMult2, b1), 
                                      e3.rgb * _EmissiveMult3, b2),

--- a/Examples/SplatMapping/Shaders/SplatBlend_1Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlend_1Layer.shader
@@ -58,11 +58,11 @@ Shader "VertexPainter/SplatBlend_1Layer"
          float2 uv1 = IN.uv_Tex1 * _TexScale1;
          INIT_FLOW
          #if (_FLOWDRIFT || !_PARALLAXMAP)
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
          #endif
          
          #if _PARALLAXMAP
@@ -73,13 +73,13 @@ Shader "VertexPainter/SplatBlend_1Layer"
          fuv1 += offset;
          fuv2 += offset;
          #endif
-         c1 = FETCH_TEX1(_Tex1, uv1);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
          #endif
 
          c1 *= _Tint1;
 
          #if _METALLICGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, uv1);
+         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, _GlossinessTex1, uv1);
          o.Smoothness = g1.a;
          o.Metallic = g1.r;
          #else
@@ -89,12 +89,12 @@ Shader "VertexPainter/SplatBlend_1Layer"
          
          
          #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
          o.Emission = e1.rgb * _EmissiveMult1;
          #endif
          
          #if _NORMALMAP
-         fixed4 n1 = FETCH_TEX1(_Normal1, uv1);
+         fixed4 n1 = FETCH_TEX1(_Normal1, _Normal1, uv1);
          o.Normal = UnpackNormal(n1);
          #endif
          

--- a/Examples/SplatMapping/Shaders/SplatBlend_2Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlend_2Layer.shader
@@ -75,14 +75,14 @@ Shader "VertexPainter/SplatBlend_2Layer"
          float2 uv2 = IN.uv_Tex1 * _TexScale2;
          INIT_FLOW
          #if _FLOWDRIFT || !_PARALLAXMAP 
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
-         fixed4 c2 = FETCH_TEX2(_Tex2, uv2);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         fixed4 c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
-         fixed4 c2 = lerp(tex2D(_Tex2, uv2), tex2D(_Tex2, uv2*_DistUVScale2), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c2 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2*_DistUVScale2), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
-         fixed4 c2 = tex2D(_Tex2, uv2);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
+         fixed4 c2 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2);
          #endif
 
          
@@ -92,10 +92,10 @@ Shader "VertexPainter/SplatBlend_2Layer"
          #if _FLOW2
             b1 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX2 (_Normal2, uv2) - 0.5;
+               half4 rn = FETCH_TEX2 (_Normal2, _Normal1, uv2) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
                #endif
             #endif
          #endif
@@ -106,8 +106,8 @@ Shader "VertexPainter/SplatBlend_2Layer"
          float2 offset = ParallaxOffset (lerp(c1.a, c2.a, b1), parallax, IN.viewDir);
          uv1 += offset;
          uv2 += offset;
-         c1 = FETCH_TEX1(_Tex1, uv1);
-         c2 = FETCH_TEX2(_Tex2, uv2);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
          #if (_FLOW1 || _FLOW2 || _FLOW3 || _FLOW4 || _FLOW5)
          fuv1 += offset;
          fuv2 += offset;
@@ -117,8 +117,8 @@ Shader "VertexPainter/SplatBlend_2Layer"
          fixed4 c = lerp(c1 * _Tint1, c2 * _Tint2, b1);
          
          #if _METALLICGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, uv1);
-         fixed4 g2 = FETCH_TEX2(_GlossinessTex2, uv2);
+         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, _GlossinessTex1, uv1);
+         fixed4 g2 = FETCH_TEX2(_GlossinessTex2, _GlossinessTex1, uv2);
          fixed4 gf = lerp(g1, g2, b1);
          o.Smoothness = gf.a;
          o.Metallic = gf.r;
@@ -128,14 +128,14 @@ Shader "VertexPainter/SplatBlend_2Layer"
          #endif
          
          #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
-         fixed4 e2 = FETCH_TEX2(_Emissive2, uv2);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
+         fixed4 e2 = FETCH_TEX2(_Emissive2, _Emissive1, uv2);
          o.Emission = lerp(e1.rgb * _EmissiveMult1, e2.rgb * _EmissiveMult2, b1);
          #endif
          
          #if _NORMALMAP
-         half4 n1 = FETCH_TEX1 (_Normal1, uv1);
-         half4 n2 = FETCH_TEX2 (_Normal2, uv2);
+         half4 n1 = FETCH_TEX1 (_Normal1, _Normal1, uv1);
+         half4 n2 = FETCH_TEX2 (_Normal2, _Normal1, uv2);
          o.Normal = UnpackNormal(lerp(n1, n2, b1));
          #endif
          o.Albedo = c.rgb;

--- a/Examples/SplatMapping/Shaders/SplatBlend_3Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlend_3Layer.shader
@@ -88,17 +88,17 @@ Shader "VertexPainter/SplatBlend_3Layer"
          float2 uv3 = IN.uv_Tex1 * _TexScale3;
          INIT_FLOW
          #if _FLOWDRIFT || !_PARALLAXMAP 
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
-         fixed4 c2 = FETCH_TEX2(_Tex2, uv2);
-         fixed4 c3 = FETCH_TEX3(_Tex3, uv3);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         fixed4 c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         fixed4 c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
-         fixed4 c2 = lerp(tex2D(_Tex2, uv2), tex2D(_Tex2, uv2*_DistUVScale2), dist);
-         fixed4 c3 = lerp(tex2D(_Tex3, uv3), tex2D(_Tex3, uv3*_DistUVScale3), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c2 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2*_DistUVScale2), dist);
+         fixed4 c3 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3*_DistUVScale3), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
-         fixed4 c2 = tex2D(_Tex2, uv2);
-         fixed4 c3 = tex2D(_Tex3, uv3);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
+         fixed4 c2 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2);
+         fixed4 c3 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3);
          #endif
          
          half b1 = HeightBlend(c1.a, c2.a, IN.color.r, _Contrast2);
@@ -108,22 +108,22 @@ Shader "VertexPainter/SplatBlend_3Layer"
          #if _FLOW2
             b1 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX2 (_Normal2, uv2) - 0.5;
+               half4 rn = FETCH_TEX2 (_Normal2, _Normal1, uv2) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
                #endif
             #endif
          #endif
          #if _FLOW3
             b2 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX3 (_Normal3, uv3) - 0.5;
+               half4 rn = FETCH_TEX3 (_Normal3, _Normal1, uv3) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
                #endif
             #endif
          #endif
@@ -135,9 +135,9 @@ Shader "VertexPainter/SplatBlend_3Layer"
          uv1 += offset;
          uv2 += offset;
          uv3 += offset;
-         c1 = FETCH_TEX1(_Tex1, uv1);
-         c2 = FETCH_TEX2(_Tex2, uv2);
-         c3 = FETCH_TEX3(_Tex3, uv3);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
           #if (_FLOW1 || _FLOW2 || _FLOW3 || _FLOW4 || _FLOW5)
          fuv1 += offset;
          fuv2 += offset;
@@ -147,9 +147,9 @@ Shader "VertexPainter/SplatBlend_3Layer"
          fixed4 c = lerp(lerp(c1 * _Tint1, c2 * _Tint2, b1), c3 * _Tint3, b2);
          
          #if _METALLICGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, uv1);
-         fixed4 g2 = FETCH_TEX2(_GlossinessTex2, uv2);
-         fixed4 g3 = FETCH_TEX3(_GlossinessTex3, uv3);
+         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, _GlossinessTex1, uv1);
+         fixed4 g2 = FETCH_TEX2(_GlossinessTex2, _GlossinessTex1, uv2);
+         fixed4 g3 = FETCH_TEX3(_GlossinessTex3, _GlossinessTex1, uv3);
          fixed4 gf = lerp(lerp(g1, g2, b1), g3, b2);
          o.Smoothness = gf.a;
          o.Metallic = gf.r;
@@ -159,18 +159,18 @@ Shader "VertexPainter/SplatBlend_3Layer"
          #endif
          
          #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
-         fixed4 e2 = FETCH_TEX2(_Emissive2, uv2);
-         fixed4 e3 = FETCH_TEX3(_Emissive3, uv3);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
+         fixed4 e2 = FETCH_TEX2(_Emissive2, _Emissive1, uv2);
+         fixed4 e3 = FETCH_TEX3(_Emissive3, _Emissive1, uv3);
          o.Emission = lerp(lerp(e1.rgb * _EmissiveMult1, 
                                 e2.rgb * _EmissiveMult2, b1), 
                                 e3.rgb * _EmissiveMult3, b2);
          #endif
          
          #if _NORMALMAP
-         half4 n1 = (FETCH_TEX1 (_Normal1, uv1));
-         half4 n2 = (FETCH_TEX2 (_Normal2, uv2));
-         half4 n3 = (FETCH_TEX3 (_Normal3, uv3));
+         half4 n1 = (FETCH_TEX1 (_Normal1, _Normal1, uv1));
+         half4 n2 = (FETCH_TEX2 (_Normal2, _Normal1, uv2));
+         half4 n3 = (FETCH_TEX3 (_Normal3, _Normal1, uv3));
          o.Normal = UnpackNormal(lerp(lerp(n1, n2, b1), n3, b2));
          #endif
          

--- a/Examples/SplatMapping/Shaders/SplatBlend_4Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlend_4Layer.shader
@@ -108,20 +108,20 @@ Shader "VertexPainter/SplatBlend_4Layer"
          float2 uv4 = IN.uv_Tex1 * _TexScale4;
          INIT_FLOW
          #if _FLOWDRIFT || !_PARALLAXMAP
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
-         fixed4 c2 = FETCH_TEX2(_Tex2, uv2);
-         fixed4 c3 = FETCH_TEX3(_Tex3, uv3);
-         fixed4 c4 = FETCH_TEX4(_Tex4, uv4);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         fixed4 c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         fixed4 c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+         fixed4 c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
-         fixed4 c2 = lerp(tex2D(_Tex2, uv2), tex2D(_Tex2, uv2*_DistUVScale2), dist);
-         fixed4 c3 = lerp(tex2D(_Tex3, uv3), tex2D(_Tex3, uv3*_DistUVScale3), dist);
-         fixed4 c4 = lerp(tex2D(_Tex4, uv4), tex2D(_Tex4, uv4*_DistUVScale4), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c2 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2*_DistUVScale2), dist);
+         fixed4 c3 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3*_DistUVScale3), dist);
+         fixed4 c4 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4*_DistUVScale4), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
-         fixed4 c2 = tex2D(_Tex2, uv2);
-         fixed4 c3 = tex2D(_Tex3, uv3);
-         fixed4 c4 = tex2D(_Tex4, uv4);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
+         fixed4 c2 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2);
+         fixed4 c3 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3);
+         fixed4 c4 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4);
          #endif
          half b1 = HeightBlend(c1.a, c2.a, IN.color.r, _Contrast2);
          fixed h1 = lerp(c1.a, c2.a, b1);
@@ -132,36 +132,36 @@ Shader "VertexPainter/SplatBlend_4Layer"
          #if _FLOW2
             b1 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX2 (_Normal2, uv2) - 0.5;
+               half4 rn = FETCH_TEX2 (_Normal2, _Normal1, uv2) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
                #endif
             #endif
          #endif
          #if _FLOW3
             b2 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX3 (_Normal3, uv3) - 0.5;
+               half4 rn = FETCH_TEX3 (_Normal3, _Normal1, uv3) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
                #endif
             #endif
          #endif
          #if _FLOW4
             b3 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX4 (_Normal4, uv4) - 0.5;
+               half4 rn = FETCH_TEX4 (_Normal4, _Normal1, uv4) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                uv3 += rn.xy * b3 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
-                  c3 = FETCH_TEX3(_Tex3, uv3);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+                  c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
                #endif
             #endif
          #endif
@@ -173,10 +173,10 @@ Shader "VertexPainter/SplatBlend_4Layer"
          uv2 += offset;
          uv3 += offset;
          uv4 += offset;
-         c1 = FETCH_TEX1(_Tex1, uv1);
-         c2 = FETCH_TEX2(_Tex2, uv2);
-         c3 = FETCH_TEX3(_Tex3, uv3);
-         c4 = FETCH_TEX4(_Tex4, uv4);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+         c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
          #if (_FLOW1 || _FLOW2 || _FLOW3 || _FLOW4 || _FLOW5)
          fuv1 += offset;
          fuv2 += offset;
@@ -187,10 +187,10 @@ Shader "VertexPainter/SplatBlend_4Layer"
          fixed4 c = lerp(lerp(lerp(c1 * _Tint1, c2 * _Tint2, b1), c3 * _Tint3, b2), c4 * _Tint4, b3);
          
          #if _METALLICGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, uv1);
-         fixed4 g2 = FETCH_TEX2(_GlossinessTex2, uv2);
-         fixed4 g3 = FETCH_TEX3(_GlossinessTex3, uv3);
-         fixed4 g4 = FETCH_TEX4(_GlossinessTex4, uv4);
+         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, _GlossinessTex1, uv1);
+         fixed4 g2 = FETCH_TEX2(_GlossinessTex2, _GlossinessTex1, uv2);
+         fixed4 g3 = FETCH_TEX3(_GlossinessTex3, _GlossinessTex1, uv3);
+         fixed4 g4 = FETCH_TEX4(_GlossinessTex4, _GlossinessTex1, uv4);
          fixed4 gf = lerp(lerp(lerp(g1, g2, b1), g3, b2), g4, b3);
          o.Smoothness = gf.a;
          o.Metallic = gf.r;
@@ -201,10 +201,10 @@ Shader "VertexPainter/SplatBlend_4Layer"
 
          
          #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
-         fixed4 e2 = FETCH_TEX2(_Emissive2, uv2);
-         fixed4 e3 = FETCH_TEX3(_Emissive3, uv3);
-         fixed4 e4 = FETCH_TEX4(_Emissive4, uv4);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
+         fixed4 e2 = FETCH_TEX2(_Emissive2, _Emissive1, uv2);
+         fixed4 e3 = FETCH_TEX3(_Emissive3, _Emissive1, uv3);
+         fixed4 e4 = FETCH_TEX4(_Emissive4, _Emissive1, uv4);
          o.Emission = lerp(lerp(lerp(e1.rgb * _EmissiveMult1, 
                                      e2.rgb * _EmissiveMult2, b1), 
                                      e3.rgb * _EmissiveMult3, b2),
@@ -213,10 +213,10 @@ Shader "VertexPainter/SplatBlend_4Layer"
          
          
          #if _NORMALMAP
-         half4 n1 =  (FETCH_TEX1 (_Normal1, uv1));
-         half4 n2 =  (FETCH_TEX2 (_Normal2, uv2));
-         half4 n3 =  (FETCH_TEX3 (_Normal3, uv3));
-         half4 n4 =  (FETCH_TEX4 (_Normal4, uv4));
+         half4 n1 =  (FETCH_TEX1 (_Normal1, _Normal1, uv1));
+         half4 n2 =  (FETCH_TEX2 (_Normal2, _Normal1, uv2));
+         half4 n3 =  (FETCH_TEX3 (_Normal3, _Normal1, uv3));
+         half4 n4 =  (FETCH_TEX4 (_Normal4, _Normal1, uv4));
          o.Normal = UnpackNormal(lerp(lerp(lerp(n1, n2, b1), n3, b2), n4, b3));
          #endif
          

--- a/Examples/SplatMapping/Shaders/SplatBlend_5Layer.shader
+++ b/Examples/SplatMapping/Shaders/SplatBlend_5Layer.shader
@@ -118,23 +118,23 @@ Shader "VertexPainter/SplatBlend_5Layer"
          float2 uv5 = IN.uv_Tex1 * _TexScale5;
          INIT_FLOW
          #if _FLOWDRIFT || !_PARALLAXMAP
-         fixed4 c1 = FETCH_TEX1(_Tex1, uv1);
-         fixed4 c2 = FETCH_TEX2(_Tex2, uv2);
-         fixed4 c3 = FETCH_TEX3(_Tex3, uv3);
-         fixed4 c4 = FETCH_TEX4(_Tex4, uv4);
-         fixed4 c5 = FETCH_TEX5(_Tex5, uv5);
+         fixed4 c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         fixed4 c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         fixed4 c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+         fixed4 c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
+         fixed4 c5 = FETCH_TEX5(_Tex5, _Tex1, uv5);
          #elif _DISTBLEND
-         fixed4 c1 = lerp(tex2D(_Tex1, uv1), tex2D(_Tex1, uv1*_DistUVScale1), dist);
-         fixed4 c2 = lerp(tex2D(_Tex2, uv2), tex2D(_Tex2, uv2*_DistUVScale2), dist);
-         fixed4 c3 = lerp(tex2D(_Tex3, uv3), tex2D(_Tex3, uv3*_DistUVScale3), dist);
-         fixed4 c4 = lerp(tex2D(_Tex4, uv4), tex2D(_Tex4, uv4*_DistUVScale4), dist);
-         fixed4 c5 = lerp(tex2D(_Tex5, uv5), tex2D(_Tex5, uv5*_DistUVScale5), dist);
+         fixed4 c1 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1*_DistUVScale1), dist);
+         fixed4 c2 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2*_DistUVScale2), dist);
+         fixed4 c3 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3*_DistUVScale3), dist);
+         fixed4 c4 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4*_DistUVScale4), dist);
+         fixed4 c5 = lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_Tex5, _Tex1, uv5), UNITY_SAMPLE_TEX2D_SAMPLER(_Tex5, _Tex1, uv5*_DistUVScale5), dist);
          #else
-         fixed4 c1 = tex2D(_Tex1, uv1);
-         fixed4 c2 = tex2D(_Tex2, uv2);
-         fixed4 c3 = tex2D(_Tex3, uv3);
-         fixed4 c4 = tex2D(_Tex4, uv4);
-         fixed4 c5 = tex2D(_Tex5, uv5);
+         fixed4 c1 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex1, _Tex1, uv1);
+         fixed4 c2 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex2, _Tex1, uv2);
+         fixed4 c3 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex3, _Tex1, uv3);
+         fixed4 c4 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex4, _Tex1, uv4);
+         fixed4 c5 = UNITY_SAMPLE_TEX2D_SAMPLER(_Tex5, _Tex1, uv5);
          #endif
          half b1 = HeightBlend(c1.a, c2.a, IN.color.r, _Contrast2);
          fixed h1 = lerp(c1.a, c2.a, b1);
@@ -148,52 +148,52 @@ Shader "VertexPainter/SplatBlend_5Layer"
          #if _FLOW2
             b1 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX2 (_Normal2, uv2) - 0.5;
+               half4 rn = FETCH_TEX2 (_Normal2, _Normal1, uv2) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
                #endif
             #endif
          #endif
          #if _FLOW3
             b2 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX3 (_Normal3, uv3) - 0.5;
+               half4 rn = FETCH_TEX3 (_Normal3, _Normal1, uv3) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
                #endif
             #endif
          #endif
          #if _FLOW4
             b3 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX4 (_Normal4, uv4) - 0.5;
+               half4 rn = FETCH_TEX4 (_Normal4, _Normal1, uv4) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                uv3 += rn.xy * b3 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
-                  c3 = FETCH_TEX3(_Tex3, uv3);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+                  c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
                #endif
             #endif
          #endif
          #if _FLOW5
             b4 *= _FlowAlpha;
             #if _FLOWREFRACTION && _NORMALMAP
-               half4 rn = FETCH_TEX5 (_Normal5, uv5) - 0.5;
+               half4 rn = FETCH_TEX5 (_Normal5, _Normal1, uv5) - 0.5;
                uv1 += rn.xy * b1 * _FlowRefraction;
                uv2 += rn.xy * b2 * _FlowRefraction;
                uv3 += rn.xy * b3 * _FlowRefraction;
                uv4 += rn.xy * b4 * _FlowRefraction;
                #if !_PARALLAXMAP 
-                  c1 = FETCH_TEX1(_Tex1, uv1);
-                  c2 = FETCH_TEX2(_Tex2, uv2);
-                  c3 = FETCH_TEX3(_Tex3, uv3);
-                  c4 = FETCH_TEX4(_Tex4, uv4);
+                  c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+                  c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+                  c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+                  c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
                #endif
             #endif
          #endif
@@ -208,11 +208,11 @@ Shader "VertexPainter/SplatBlend_5Layer"
          uv3 += offset;
          uv4 += offset;
          uv5 += offset;
-         c1 = FETCH_TEX1(_Tex1, uv1);
-         c2 = FETCH_TEX2(_Tex2, uv2);
-         c3 = FETCH_TEX3(_Tex3, uv3);
-         c4 = FETCH_TEX4(_Tex4, uv4);
-         c5 = FETCH_TEX5(_Tex5, uv5);
+         c1 = FETCH_TEX1(_Tex1, _Tex1, uv1);
+         c2 = FETCH_TEX2(_Tex2, _Tex1, uv2);
+         c3 = FETCH_TEX3(_Tex3, _Tex1, uv3);
+         c4 = FETCH_TEX4(_Tex4, _Tex1, uv4);
+         c5 = FETCH_TEX5(_Tex5, _Tex1, uv5);
          #if (_FLOW1 || _FLOW2 || _FLOW3 || _FLOW4 || _FLOW5)
          fuv1 += offset;
          fuv2 += offset;
@@ -222,20 +222,20 @@ Shader "VertexPainter/SplatBlend_5Layer"
          fixed4 c = lerp(lerp(lerp(lerp(c1 * _Tint1, c2 * _Tint2, b1), c3 * _Tint3, b2), c4 * _Tint4, b3), c5 * _Tint5, b4);
          
          #if _NORMALMAP
-         half4 n1 =  (FETCH_TEX1 (_Normal1, uv1));
-         half4 n2 =  (FETCH_TEX2 (_Normal2, uv2));
-         half4 n3 =  (FETCH_TEX3 (_Normal3, uv3));
-         half4 n4 =  (FETCH_TEX4 (_Normal4, uv4));
-         half4 n5 =  (FETCH_TEX5 (_Normal5, uv5));
+         half4 n1 =  (FETCH_TEX1 (_Normal1, _Normal1, uv1));
+         half4 n2 =  (FETCH_TEX2 (_Normal2, _Normal1, uv2));
+         half4 n3 =  (FETCH_TEX3 (_Normal3, _Normal1, uv3));
+         half4 n4 =  (FETCH_TEX4 (_Normal4, _Normal1, uv4));
+         half4 n5 =  (FETCH_TEX5 (_Normal5, _Normal1, uv5));
          o.Normal = UnpackNormal(lerp(lerp(lerp(lerp(n1, n2, b1), n3, b2), n4, b3), n5, b4));
          #endif
          
          #if _METALLICGLOSSMAP
-         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, uv1);
-         fixed4 g2 = FETCH_TEX2(_GlossinessTex2, uv2);
-         fixed4 g3 = FETCH_TEX3(_GlossinessTex3, uv3);
-         fixed4 g4 = FETCH_TEX4(_GlossinessTex4, uv4);
-         fixed4 g5 = FETCH_TEX5(_GlossinessTex5, uv4);
+         fixed4 g1 = FETCH_TEX1(_GlossinessTex1, _GlossinessTex1, uv1);
+         fixed4 g2 = FETCH_TEX2(_GlossinessTex2, _GlossinessTex1, uv2);
+         fixed4 g3 = FETCH_TEX3(_GlossinessTex3, _GlossinessTex1, uv3);
+         fixed4 g4 = FETCH_TEX4(_GlossinessTex4, _GlossinessTex1, uv4);
+         fixed4 g5 = FETCH_TEX5(_GlossinessTex5, _GlossinessTex1, uv4);
          fixed4 gf = lerp(lerp(lerp(lerp(g1, g2, b1), g3, b2), g4, b3), g5, b4);
          o.Smoothness = gf.a;
          o.Metallic = gf.r;
@@ -245,11 +245,11 @@ Shader "VertexPainter/SplatBlend_5Layer"
          #endif
 
          #if _EMISSION
-         fixed4 e1 = FETCH_TEX1(_Emissive1, uv1);
-         fixed4 e2 = FETCH_TEX2(_Emissive2, uv2);
-         fixed4 e3 = FETCH_TEX3(_Emissive3, uv3);
-         fixed4 e4 = FETCH_TEX4(_Emissive4, uv4);
-         fixed4 e5 = FETCH_TEX5(_Emissive5, uv5);
+         fixed4 e1 = FETCH_TEX1(_Emissive1, _Emissive1, uv1);
+         fixed4 e2 = FETCH_TEX2(_Emissive2, _Emissive1, uv2);
+         fixed4 e3 = FETCH_TEX3(_Emissive3, _Emissive1, uv3);
+         fixed4 e4 = FETCH_TEX4(_Emissive4, _Emissive1, uv4);
+         fixed4 e5 = FETCH_TEX5(_Emissive5, _Emissive1, uv5);
          o.Emission = lerp(lerp(lerp(lerp(e1.rgb * _EmissiveMult1, 
                                      e2.rgb * _EmissiveMult2, b1), 
                                      e3.rgb * _EmissiveMult3, b2),

--- a/Examples/SplatMapping/Shaders/SplatBlend_Shared.cginc
+++ b/Examples/SplatMapping/Shaders/SplatBlend_Shared.cginc
@@ -1,6 +1,3 @@
-
-
-
 struct Input 
 {
    float2 uv_Tex1;
@@ -14,10 +11,17 @@ struct Input
    #endif
 };
 
+fixed4 _Tint1, _SpecColor1;
+half _Glossiness1, _Metallic1, _Parallax1, _TexScale1, _Contrast1, _EmissiveMult1;
+float _DistUVScale1;
+UNITY_DECLARE_TEX2D(_Tex1);
+UNITY_DECLARE_TEX2D(_Normal1);
+UNITY_DECLARE_TEX2D(_GlossinessTex1);
+UNITY_DECLARE_TEX2D(_Emissive1);
+UNITY_DECLARE_TEX2D(_SpecGlossMap1);
 // macro for one layer of texture data      
-#define LAYER(__N) sampler2D _Tex##__N; fixed4 _Tint##__N; sampler2D _Normal##__N; sampler2D _GlossinessTex##__N; half _Glossiness##__N; half _Metallic##__N; half _Parallax##__N; half _TexScale##__N; half _Contrast##__N; sampler2D _Emissive##__N; half _EmissiveMult##__N; fixed4 _SpecColor##__N; sampler2D _SpecGlossMap##__N; float _DistUVScale##__N;
+#define LAYER(__N) UNITY_DECLARE_TEX2D_NOSAMPLER(_Tex##__N); fixed4 _Tint##__N; UNITY_DECLARE_TEX2D_NOSAMPLER(_Normal##__N); UNITY_DECLARE_TEX2D_NOSAMPLER(_GlossinessTex##__N); half _Glossiness##__N; half _Metallic##__N; half _Parallax##__N; half _TexScale##__N; half _Contrast##__N; UNITY_DECLARE_TEX2D_NOSAMPLER(_Emissive##__N); half _EmissiveMult##__N; fixed4 _SpecColor##__N; UNITY_DECLARE_TEX2D_NOSAMPLER(_SpecGlossMap##__N); float _DistUVScale##__N;
 
-LAYER(1)
 LAYER(2)
 LAYER(3)
 LAYER(4)
@@ -46,43 +50,43 @@ float _DistBlendMax;
 
 // we define the function based on what channel is actively compiled for flow data - other combinations else into a standard tex2D
 #if _FLOW1
-#define FETCH_TEX1(_T, _UV) lerp(tex2D(_T, fuv1), tex2D(_T, fuv2), flowInterp)
+#define FETCH_TEX1(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv1), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv2), flowInterp)
 #elif _DISTBLEND
-#define FETCH_TEX1(_T, _UV) lerp(tex2D(_T, _UV), tex2D(_T, _UV*_DistUVScale1), dist)
+#define FETCH_TEX1(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV*_DistUVScale1), dist)
 #else
-#define FETCH_TEX1(_T, _UV) tex2D(_T, _UV)
+#define FETCH_TEX1(_T, _S, _UV) UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV)
 #endif
 
 #if _FLOW2
-#define FETCH_TEX2(_T, _UV) lerp(tex2D(_T, fuv1), tex2D(_T, fuv2), flowInterp)
+#define FETCH_TEX2(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv1), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv2), flowInterp)
 #elif _DISTBLEND
-#define FETCH_TEX2(_T, _UV) lerp(tex2D(_T, _UV), tex2D(_T, _UV*_DistUVScale2), dist)
+#define FETCH_TEX2(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV*_DistUVScale2), dist)
 #else
-#define FETCH_TEX2(_T, _UV) tex2D(_T, _UV)
+#define FETCH_TEX2(_T, _S, _UV) UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV)
 #endif
 
 #if _FLOW3
-#define FETCH_TEX3(_T, _UV) lerp(tex2D(_T, fuv1), tex2D(_T, fuv2), flowInterp)
+#define FETCH_TEX3(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv1), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv2), flowInterp)
 #elif _DISTBLEND
-#define FETCH_TEX3(_T, _UV) lerp(tex2D(_T, _UV), tex2D(_T, _UV*_DistUVScale3), dist)
+#define FETCH_TEX3(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV*_DistUVScale3), dist)
 #else
-#define FETCH_TEX3(_T, _UV) tex2D(_T, _UV)
+#define FETCH_TEX3(_T, _S, _UV) UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV)
 #endif
 
 #if _FLOW4
-#define FETCH_TEX4(_T, _UV) lerp(tex2D(_T, fuv1), tex2D(_T, fuv2), flowInterp)
+#define FETCH_TEX4(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv1), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv2), flowInterp)
 #elif _DISTBLEND
-#define FETCH_TEX4(_T, _UV) lerp(tex2D(_T, _UV), tex2D(_T, _UV*_DistUVScale4), dist)
+#define FETCH_TEX4(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV*_DistUVScale4), dist)
 #else
-#define FETCH_TEX4(_T, _UV) tex2D(_T, _UV)
+#define FETCH_TEX4(_T, _S, _UV) UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV)
 #endif
 
 #if _FLOW5
-#define FETCH_TEX5(_T, _UV) lerp(tex2D(_T, fuv1), tex2D(_T, fuv2), flowInterp)
+#define FETCH_TEX5(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv1), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, fuv2), flowInterp)
 #elif _DISTBLEND
-#define FETCH_TEX5(_T, _UV) lerp(tex2D(_T, _UV), tex2D(_T, _UV*_DistUVScale5), dist)
+#define FETCH_TEX5(_T, _S, _UV) lerp(UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV), UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV*_DistUVScale5), dist)
 #else
-#define FETCH_TEX5(_T, _UV) tex2D(_T, _UV)
+#define FETCH_TEX5(_T, _S, _UV) UNITY_SAMPLE_TEX2D_SAMPLER(_T, _S, _UV)
 #endif  
 
 // given two height values (from textures) and a height value for the current pixel (from vertex)

--- a/VertexPainterPro_Preview.shader
+++ b/VertexPainterPro_Preview.shader
@@ -152,7 +152,8 @@ Shader "Hidden/VertexPainterPro_Preview"
          
          v2f vert (appdata v)
          {
-            v2f o;
+			v2f o;
+			UNITY_INITIALIZE_OUTPUT(v2f, o);
             o.uv = v.uv0.xy;
             o.vertex = UnityObjectToClipPos(v.vertex); 
             if (_tab > 1.9 && _tab < 2.1)


### PR DESCRIPTION
The 4 and 5 Layer shaders end up with way too many seperate texture samplers that exceeds the pixel shader 5.0 limits. I've reconfigured the shaders to have only a base set of samplers derived from the first layer of textures, while the subsequent layers' textures will use the base layer's samplers.