### PR TITLE
Fix for high CPU/GPU usage.

### DIFF
--- a/Editor/VertexPainterWindow_GUI.cs
+++ b/Editor/VertexPainterWindow_GUI.cs
@@ -662,8 +662,10 @@ namespace JBooth.VertexPainterPro
             EndStroke();
          }
 
-         SceneView.onSceneGUIDelegate -= this.OnSceneGUI;
-         SceneView.onSceneGUIDelegate += this.OnSceneGUI;
+         //SceneView.onSceneGUIDelegate -= this.OnSceneGUI;
+         //SceneView.onSceneGUIDelegate += this.OnSceneGUI;
+         SceneView.duringSceneGui -= this.OnSceneGUI;
+         SceneView.duringSceneGui += this.OnSceneGUI;
 
          Undo.undoRedoPerformed -= this.OnUndo;
          Undo.undoRedoPerformed += this.OnUndo;
@@ -691,7 +693,8 @@ namespace JBooth.VertexPainterPro
          UpdateDisplayMode();
          showVertexShader = show;
          DestroyImmediate(VertexInstanceStream.vertexShaderMat);
-         SceneView.onSceneGUIDelegate -= this.OnSceneGUI;
+         //SceneView.onSceneGUIDelegate -= this.OnSceneGUI;
+         SceneView.duringSceneGui -= this.OnSceneGUI;
       }
    }
 }

--- a/Editor/VertexPainterWindow_GUI.cs
+++ b/Editor/VertexPainterWindow_GUI.cs
@@ -662,10 +662,13 @@ namespace JBooth.VertexPainterPro
             EndStroke();
          }
 
-         //SceneView.onSceneGUIDelegate -= this.OnSceneGUI;
-         //SceneView.onSceneGUIDelegate += this.OnSceneGUI;
+#if UNITY_2019_1_OR_NEWER
          SceneView.duringSceneGui -= this.OnSceneGUI;
          SceneView.duringSceneGui += this.OnSceneGUI;
+#else
+         SceneView.onSceneGUIDelegate -= this.OnSceneGUI;
+         SceneView.onSceneGUIDelegate += this.OnSceneGUI;
+#endif
 
          Undo.undoRedoPerformed -= this.OnUndo;
          Undo.undoRedoPerformed += this.OnUndo;

--- a/Editor/VertexPainterWindow_GUI.cs
+++ b/Editor/VertexPainterWindow_GUI.cs
@@ -696,8 +696,11 @@ namespace JBooth.VertexPainterPro
          UpdateDisplayMode();
          showVertexShader = show;
          DestroyImmediate(VertexInstanceStream.vertexShaderMat);
-         //SceneView.onSceneGUIDelegate -= this.OnSceneGUI;
+#if UNITY_2019_1_OR_NEWER
          SceneView.duringSceneGui -= this.OnSceneGUI;
+#else
+         SceneView.onSceneGUIDelegate -= this.OnSceneGUI;
+#endif
       }
    }
 }

--- a/Editor/VertexPainterWindow_Painting.cs
+++ b/Editor/VertexPainterWindow_Painting.cs
@@ -1700,7 +1700,11 @@ namespace JBooth.VertexPainterPro
             {
                Handles.color = showVertexColor;
                Vector3 wp = mtx.MultiplyPoint(j.verts[i]);
+#if UNITY_5_5_OR_NEWER
                Handles.SphereHandleCap(0, wp, Quaternion.identity, HandleUtility.GetHandleSize(wp) * 0.02f * showVertexSize, EventType.Repaint);
+#else
+               Handles.SphereCap(0, wp, Quaternion.identity, HandleUtility.GetHandleSize(wp) * 0.02f * showVertexSize);
+#endif
 
                if (showNormals)
                {
@@ -2337,7 +2341,11 @@ namespace JBooth.VertexPainterPro
 
          if (brushVisualization == BrushVisualization.Sphere)
          {
+#if UNITY_5_5_OR_NEWER
             Handles.SphereHandleCap(0, point, Quaternion.identity, brushSize * 2, EventType.Repaint);
+#else
+            Handles.SphereCap(0, point, Quaternion.identity, brushSize * 2);
+#endif
          }
          else
          {

--- a/Editor/VertexPainterWindow_Painting.cs
+++ b/Editor/VertexPainterWindow_Painting.cs
@@ -1700,7 +1700,7 @@ namespace JBooth.VertexPainterPro
             {
                Handles.color = showVertexColor;
                Vector3 wp = mtx.MultiplyPoint(j.verts[i]);
-               Handles.SphereCap(0, wp, Quaternion.identity, HandleUtility.GetHandleSize(wp) * 0.02f * showVertexSize);
+               Handles.SphereHandleCap(0, wp, Quaternion.identity, HandleUtility.GetHandleSize(wp) * 0.02f * showVertexSize, EventType.Repaint);
 
                if (showNormals)
                {

--- a/Editor/VertexPainterWindow_Painting.cs
+++ b/Editor/VertexPainterWindow_Painting.cs
@@ -2359,11 +2359,10 @@ namespace JBooth.VertexPainterPro
          }
 
          // only paint once per frame
-         if (tab != Tab.Flow && Event.current.type != EventType.Repaint)
+         if (tab != Tab.Flow && Event.current.type != EventType.Repaint && Event.current.type != EventType.MouseMove)
          {
             return;
          }
-
 
          if (jobs.Length > 0 && painting)
          {
@@ -2404,9 +2403,12 @@ namespace JBooth.VertexPainterPro
             }
          }
 
-         // update views
-         sceneView.Repaint();
-         HandleUtility.Repaint();
+        // update views
+        if (Event.current.type != EventType.Repaint)
+        {
+            sceneView.Repaint();
+            HandleUtility.Repaint();
+        }        
       }
    }
 }

--- a/Editor/VertexPainterWindow_Painting.cs
+++ b/Editor/VertexPainterWindow_Painting.cs
@@ -2337,7 +2337,7 @@ namespace JBooth.VertexPainterPro
 
          if (brushVisualization == BrushVisualization.Sphere)
          {
-            Handles.SphereCap(0, point, Quaternion.identity, brushSize * 2);
+            Handles.SphereHandleCap(0, point, Quaternion.identity, brushSize * 2, EventType.Repaint);
          }
          else
          {


### PR DESCRIPTION
I noticed a high amount of cpu/gpu usage while the brush is active, even if nothing is happening in the scene/editor.  I think this was because in the VertexPaint OnSceneGUI, repaint events aren't getting consumed before another repaint event being created at the end of the function.  So, I added a check to only repaint on non-repaint events and then allowed the MouseMove event to pass through to the end of that function.